### PR TITLE
Add `state_class: measurement` to `Response Duration` sensors

### DIFF
--- a/packages/custom_url.yaml
+++ b/packages/custom_url.yaml
@@ -181,6 +181,7 @@ sensor:
     entity_category: diagnostic
     disabled_by_default: true
     device_class: duration
+    state_class: measurement
     unit_of_measurement: "ms"
     accuracy_decimals: 0
     web_server:

--- a/packages/healthcheck.yaml
+++ b/packages/healthcheck.yaml
@@ -183,6 +183,7 @@ sensor:
     entity_category: diagnostic
     disabled_by_default: true
     device_class: duration
+    state_class: measurement
     unit_of_measurement: "ms"
     accuracy_decimals: 0
     web_server:

--- a/packages/svitlobot.yaml
+++ b/packages/svitlobot.yaml
@@ -187,6 +187,7 @@ sensor:
     entity_category: diagnostic
     disabled_by_default: true
     device_class: duration
+    state_class: measurement
     unit_of_measurement: "ms"
     accuracy_decimals: 0
     web_server:


### PR DESCRIPTION
## Proposed change

The `Response Duration` template sensors in the `svitlobot`, `healthcheck`,
and `custom_url` packages report HTTP request latency in milliseconds but
lack `state_class`, so Home Assistant does not record long-term statistics
for them. Adding `state_class: measurement` enables HA to track and graph
latency trends over time, and pairs correctly with the existing
`device_class: duration` and `unit_of_measurement: "ms"`.

Built-in platforms (`uptime`, `wifi_signal`) get `state_class` from
ESPHome automatically; template sensors do not, which is why these three
were missed.

## Type of change

- [x] Code quality improvements to existing code or addition of tests

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] The code has been formatted using YamlLint